### PR TITLE
Retain source maps

### DIFF
--- a/packages/hecs-plugin-core/package.json
+++ b/packages/hecs-plugin-core/package.json
@@ -2,6 +2,7 @@
   "name": "hecs-plugin-core",
   "version": "0.17.0",
   "main": "dist/hecs-plugin-core.js",
+  "files": ["src", "dist"],
   "scripts": {
     "start": "webpack --watch",
     "test": "jest",

--- a/packages/hecs-plugin-core/webpack.config.js
+++ b/packages/hecs-plugin-core/webpack.config.js
@@ -56,7 +56,6 @@ module.exports = env => {
   }
   if (isProduction) {
     config.mode = 'production'
-    config.devtool = false
   }
   return config
 }

--- a/packages/hecs-plugin-physx/package.json
+++ b/packages/hecs-plugin-physx/package.json
@@ -2,6 +2,7 @@
   "name": "hecs-plugin-physx",
   "version": "0.17.0",
   "main": "dist/hecs-plugin-physx.js",
+  "files": ["src", "dist"],
   "scripts": {
     "start": "webpack --watch",
     "test": "jest",

--- a/packages/hecs-plugin-physx/webpack.config.js
+++ b/packages/hecs-plugin-physx/webpack.config.js
@@ -68,7 +68,6 @@ module.exports = env => {
   }
   if (isProduction) {
     config.mode = 'production'
-    config.devtool = false
   }
   return config
 }

--- a/packages/hecs-plugin-three/package.json
+++ b/packages/hecs-plugin-three/package.json
@@ -2,6 +2,7 @@
   "name": "hecs-plugin-three",
   "version": "0.17.0",
   "main": "dist/hecs-plugin-three.js",
+  "files": ["src", "dist"],
   "scripts": {
     "start": "webpack --watch",
     "test": "jest",

--- a/packages/hecs-plugin-three/webpack.config.js
+++ b/packages/hecs-plugin-three/webpack.config.js
@@ -71,7 +71,6 @@ module.exports = env => {
   }
   if (isProduction) {
     config.mode = 'production'
-    config.devtool = false
   }
   return config
 }

--- a/packages/hecs/package.json
+++ b/packages/hecs/package.json
@@ -2,6 +2,7 @@
   "name": "hecs",
   "version": "0.17.0",
   "main": "dist/hecs.js",
+  "files": ["src", "dist"],
   "scripts": {
     "start": "webpack --watch",
     "test": "jest",

--- a/packages/hecs/webpack.config.js
+++ b/packages/hecs/webpack.config.js
@@ -48,7 +48,6 @@ module.exports = env => {
   }
   if (isProduction) {
     config.mode = 'production'
-    config.devtool = false
   }
   return config
 }


### PR DESCRIPTION
Creates source maps in both development and production mode for webpack, then includes both the "dist" and "src" dirs so that an app can optionally include that data.

For example, `yarn add -D source-map-loader` with modifications to webpack config [here](https://webpack.js.org/loaders/source-map-loader/) will allow the end-user to see HECS source code when errors occur inside HECS itself (or its plugins).

Fixes #13 