### PR TITLE
Add `createQueries` to System

### DIFF
--- a/packages/hecs/src/System.js
+++ b/packages/hecs/src/System.js
@@ -7,8 +7,12 @@ export class System {
     this.world = world
     this.queries = {}
     this.active = true
-    for (const queryName in this.constructor.queries) {
-      const Components = this.constructor.queries[queryName]
+    this.createQueries(this.constructor.queries)
+  }
+
+  createQueries(queries) {
+    for (const queryName in queries) {
+      const Components = queries[queryName]
       this.queries[queryName] = this.world.queries.create(Components)
     }
   }


### PR DESCRIPTION
Makes it slightly easier to create queries dynamically when needed, e.g. in `System.init()` instead of from `static queries`.

Relates to #20 