### PR TITLE
Accept optional plugin options

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "nohoist": []
   },
   "scripts": {
-    "release": "lerna publish"
+    "release": "lerna publish",
+    "build": "lerna run build"
   },
   "devDependencies": {
     "lerna": "^3.22.1"

--- a/packages/hecs-plugin-three/src/Presentation.js
+++ b/packages/hecs-plugin-three/src/Presentation.js
@@ -6,19 +6,21 @@ let loader
 let textureLoader
 
 export class Presentation {
-  constructor(world) {
+  constructor(world, options) {
     this.world = world
     this.viewport = null
     this.size = { width: 1, height: 1 }
-    this.scene = this.createScene()
+    this.scene = options.scene || this.createScene()
     this.object3ds = []
-    this.renderer = this.createRenderer()
-    this.camera = new THREE.PerspectiveCamera(
-      75,
-      this.size.width / this.size.height,
-      0.1,
-      1000
-    )
+    this.renderer = options.renderer || this.createRenderer()
+    this.camera =
+      options.camera ||
+      new THREE.PerspectiveCamera(
+        75,
+        this.size.width / this.size.height,
+        0.1,
+        1000
+      )
     this.resizeObserver = new ResizeObserver(this.onResize.bind(this))
     this.capture = new Capture(this)
     if (!loader) loader = new Loader()

--- a/packages/hecs-plugin-three/src/Presentation.js
+++ b/packages/hecs-plugin-three/src/Presentation.js
@@ -13,14 +13,7 @@ export class Presentation {
     this.scene = options.scene || this.createScene()
     this.object3ds = []
     this.renderer = options.renderer || this.createRenderer()
-    this.camera =
-      options.camera ||
-      new THREE.PerspectiveCamera(
-        75,
-        this.size.width / this.size.height,
-        0.1,
-        1000
-      )
+    this.camera = options.camera || this.createCamera()
     this.resizeObserver = new ResizeObserver(this.onResize.bind(this))
     this.capture = new Capture(this)
     if (!loader) loader = new Loader()
@@ -126,5 +119,14 @@ export class Presentation {
     renderer.xr.setReferenceSpaceType('local-floor')
 
     return renderer
+  }
+
+  createCamera() {
+    return new THREE.PerspectiveCamera(
+      75,
+      this.size.width / this.size.height,
+      0.1,
+      1000
+    )
   }
 }

--- a/packages/hecs-plugin-three/src/index.js
+++ b/packages/hecs-plugin-three/src/index.js
@@ -28,9 +28,9 @@ export default createPlugin({
   plugins: [CorePlugin],
   systems,
   components,
-  decorate(world) {
+  decorate(world, options) {
     if (IS_BROWSER) {
-      world.presentation = new Presentation(world)
+      world.presentation = new Presentation(world, options)
     }
   },
 })

--- a/packages/hecs/src/World.js
+++ b/packages/hecs/src/World.js
@@ -28,14 +28,20 @@ export class World extends EventEmitter {
     this.systems.init()
   }
 
-  registerPlugin(plugin) {
+  registerPlugin(plugin, options = {}) {
     if (this.plugins.has(plugin)) {
       console.warn(`hecs: already registered plugin '${plugin.name}'`)
       return
     }
     this.plugins.set(plugin, true)
-    plugin.plugins.forEach(plugin => {
-      this.registerPlugin(plugin)
+    plugin.plugins.forEach(entry => {
+      if (entry instanceof Array) {
+        const [plugin, options = {}] = entry
+        this.registerPlugin(plugin, options)
+      } else {
+        const plugin = entry
+        this.registerPlugin(plugin)
+      }
     })
     plugin.systems.forEach(System => {
       this.systems.register(System)
@@ -44,7 +50,7 @@ export class World extends EventEmitter {
       this.components.register(Component)
     })
     if (plugin.decorate) {
-      plugin.decorate(this)
+      plugin.decorate(this, options)
     }
     console.log(`hecs: registered plugin '${plugin.name}'`)
   }


### PR DESCRIPTION
1. when plugin is an Array of the form [PluginName, {}], then accept the second param as options to the plugin
2. `hecs-plugin-three` accepts the following options:
  - renderer: a THREE.WebGLRenderer instance
  - scene: a THREE.Scene instance, possibly with lights
  - camera: a THREE.PerspectiveCamera instance

Fixes #23, #20 

Relates to #25