### PR TITLE
[three] Add optional EffectComposer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "nohoist": []
   },
   "scripts": {
-    "release": "lerna publish"
+    "release": "lerna publish",
+    "build": "lerna run build"
   },
   "devDependencies": {
     "lerna": "^3.22.1"

--- a/packages/hecs-plugin-three/src/Presentation.js
+++ b/packages/hecs-plugin-three/src/Presentation.js
@@ -6,19 +6,21 @@ let loader
 let textureLoader
 
 export class Presentation {
-  constructor(world) {
+  constructor(world, options) {
     this.world = world
     this.viewport = null
     this.size = { width: 1, height: 1 }
-    this.scene = this.createScene()
+    this.scene = options.scene || this.createScene()
     this.object3ds = []
-    this.renderer = this.createRenderer()
-    this.camera = new THREE.PerspectiveCamera(
-      75,
-      this.size.width / this.size.height,
-      0.1,
-      1000
-    )
+    this.renderer = options.renderer || this.createRenderer()
+    this.camera =
+      options.camera ||
+      new THREE.PerspectiveCamera(
+        75,
+        this.size.width / this.size.height,
+        0.1,
+        1000
+      )
     this.resizeObserver = new ResizeObserver(this.onResize.bind(this))
     this.capture = new Capture(this)
     if (!loader) loader = new Loader()

--- a/packages/hecs-plugin-three/src/Presentation.js
+++ b/packages/hecs-plugin-three/src/Presentation.js
@@ -13,14 +13,7 @@ export class Presentation {
     this.scene = options.scene || this.createScene()
     this.object3ds = []
     this.renderer = options.renderer || this.createRenderer()
-    this.camera =
-      options.camera ||
-      new THREE.PerspectiveCamera(
-        75,
-        this.size.width / this.size.height,
-        0.1,
-        1000
-      )
+    this.camera = options.camera || this.createCamera()
     this.resizeObserver = new ResizeObserver(this.onResize.bind(this))
     this.capture = new Capture(this)
     if (!loader) loader = new Loader()
@@ -126,5 +119,14 @@ export class Presentation {
     renderer.xr.setReferenceSpaceType('local-floor')
 
     return renderer
+  }
+
+  createCamera() {
+    return new THREE.PerspectiveCamera(
+      75,
+      this.size.width / this.size.height,
+      0.1,
+      1000
+    )
   }
 }

--- a/packages/hecs-plugin-three/src/Presentation.js
+++ b/packages/hecs-plugin-three/src/Presentation.js
@@ -1,4 +1,7 @@
 import * as THREE from 'three'
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer'
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass'
+
 import { Loader } from './Loader'
 import { Capture } from './Capture'
 
@@ -10,10 +13,14 @@ export class Presentation {
     this.world = world
     this.viewport = null
     this.size = { width: 1, height: 1 }
-    this.scene = options.scene || this.createScene()
     this.object3ds = []
+    this.scene = options.scene || this.createScene()
     this.renderer = options.renderer || this.createRenderer()
     this.camera = options.camera || this.createCamera()
+    this.postprocess = !!options.postprocess
+    if (this.postprocess) {
+      this.composer = options.composer || this.createComposer()
+    }
     this.resizeObserver = new ResizeObserver(this.onResize.bind(this))
     this.capture = new Capture(this)
     if (!loader) loader = new Loader()
@@ -60,14 +67,27 @@ export class Presentation {
     this.size.height = this.viewport?.offsetHeight || 1
   }
 
+  render() {
+    if (this.viewport) {
+      if (this.postprocess) {
+        this.composer.render()
+      } else {
+        this.renderer.render(this.scene, this.camera)
+      }
+    }
+  }
+
   resize() {
     this.updateSize()
     this.camera.aspect = this.size.width / this.size.height
     this.camera.updateProjectionMatrix()
     this.renderer.setSize(this.size.width, this.size.height)
-    if (this.viewport) {
-      this.renderer.render(this.scene, this.camera)
+    if (this.postprocess) {
+      this.composer.setSize(this.size.width, this.size.height)
     }
+
+    // Render immediately after resize to avoid flicker
+    this.render()
   }
 
   takePhoto(width, height) {
@@ -128,5 +148,15 @@ export class Presentation {
       0.1,
       1000
     )
+  }
+
+  createComposer() {
+    const composer = new EffectComposer(this.renderer)
+
+    const renderPass = new RenderPass(this.scene, this.camera)
+
+    composer.addPass(renderPass)
+
+    return composer
   }
 }

--- a/packages/hecs-plugin-three/src/index.js
+++ b/packages/hecs-plugin-three/src/index.js
@@ -28,9 +28,9 @@ export default createPlugin({
   plugins: [CorePlugin],
   systems,
   components,
-  decorate(world) {
+  decorate(world, options) {
     if (IS_BROWSER) {
-      world.presentation = new Presentation(world)
+      world.presentation = new Presentation(world, options)
     }
   },
 })

--- a/packages/hecs-plugin-three/src/systems/RenderSystem.js
+++ b/packages/hecs-plugin-three/src/systems/RenderSystem.js
@@ -11,9 +11,6 @@ export class RenderSystem extends System {
 
   update() {
     if (!this.presentation.viewport) return
-    this.presentation.renderer.render(
-      this.presentation.scene,
-      this.presentation.camera
-    )
+    this.presentation.render()
   }
 }

--- a/packages/hecs/src/World.js
+++ b/packages/hecs/src/World.js
@@ -28,14 +28,20 @@ export class World extends EventEmitter {
     this.systems.init()
   }
 
-  registerPlugin(plugin) {
+  registerPlugin(plugin, options = {}) {
     if (this.plugins.has(plugin)) {
       console.warn(`hecs: already registered plugin '${plugin.name}'`)
       return
     }
     this.plugins.set(plugin, true)
-    plugin.plugins.forEach(plugin => {
-      this.registerPlugin(plugin)
+    plugin.plugins.forEach(entry => {
+      if (entry instanceof Array) {
+        const [plugin, options = {}] = entry
+        this.registerPlugin(plugin, options)
+      } else {
+        const plugin = entry
+        this.registerPlugin(plugin)
+      }
     })
     plugin.systems.forEach(System => {
       this.systems.register(System)
@@ -44,7 +50,7 @@ export class World extends EventEmitter {
       this.components.register(Component)
     })
     if (plugin.decorate) {
-      plugin.decorate(this)
+      plugin.decorate(this, options)
     }
     console.log(`hecs: registered plugin '${plugin.name}'`)
   }


### PR DESCRIPTION
Allows a user to add `postprocess: true` to `hecs-plugin-three` options, and a `composer` object will be created that does a simple RenderPass instead of relying on a direct `renderer.render`:

```js
const world = new World({
  plugins: [
    CorePlugin,
    PhysXPlugin,
    [ ThreePlugin, { postprocess: true } ],
    // ...
  ]
})

// Now you can add postprocessing effects to the `hecs-plugin-three` rendering pipeline
import { OutlinePass } from "three/examples/jsm/postprocessing/OutlinePass";
const { composer, scene, camera } = world.presentation
const outlinePass = new OutlinePass(
      new Vector2(window.innerWidth, window.innerHeight),
      scene,
      camera
    );
outlinePass.visibleEdgeColor.set(0xffffff);
composer.addPass(outlinePass);
```

This PR depends on #26 