### PR TITLE
Support functional type defaults

### DIFF
--- a/packages/hecs/src/Component.js
+++ b/packages/hecs/src/Component.js
@@ -18,7 +18,14 @@ export class Component {
         this.constructor.props[key] = prop
       }
 
-      this[key] = prop.type.initial(value === undefined ? prop.default : value)
+      const initialValue =
+        value === undefined
+          ? typeof prop.default === 'function'
+            ? prop.default()
+            : prop.default
+          : value
+
+      this[key] = prop.type.initial(initialValue)
       this.props.push(prop)
     }
   }

--- a/packages/hecs/src/Component.js
+++ b/packages/hecs/src/Component.js
@@ -20,8 +20,8 @@ export class Component {
 
       const initialValue =
         value === undefined
-          ? typeof prop.default === 'function'
-            ? prop.default()
+          ? prop.defaultFn
+            ? prop.defaultFn()
             : prop.default
           : value
 

--- a/packages/hecs/tests/types.test.js
+++ b/packages/hecs/tests/types.test.js
@@ -28,6 +28,17 @@ class ConfiguredTypes extends Component {
   }
 }
 
+class FunctionalTypeDefaults extends Component {
+  static props = {
+    seed: {
+      type: NumberType,
+      default() {
+        return Math.random()
+      },
+    },
+  }
+}
+
 describe('types', () => {
   const world = new World({
     components: [BaseTypes, ConfiguredTypes],
@@ -127,5 +138,12 @@ describe('types', () => {
       expect(component.json.bar).toBe('baz')
       entity.remove(ConfiguredTypes)
     })
+  })
+
+  describe('functional type defaults', () => {
+    entity.add(FunctionalTypeDefaults)
+    const component = entity.get(FunctionalTypeDefaults)
+    expect(typeof component.seed).toBe('number')
+    entity.remove(FunctionalTypeDefaults)
   })
 })

--- a/packages/hecs/tests/types.test.js
+++ b/packages/hecs/tests/types.test.js
@@ -32,7 +32,7 @@ class FunctionalTypeDefaults extends Component {
   static props = {
     seed: {
       type: NumberType,
-      default() {
+      defaultFn() {
         return Math.random()
       },
     },


### PR DESCRIPTION
This PR aims to resolve https://github.com/gohyperr/hecs/issues/12

While this _does_ solve the issue, it also breaks some plugins that have a default that is meant to be a function.

One example of this is the `Transform` component in `hecs-plugin-core` which uses a `Vector3` as the default. This value is a function.

https://github.com/gohyperr/hecs/blob/master/packages/hecs-plugin-core/src/components/Transform.js#L21

@canadaduane i'm wondering if maybe we should use a separate key like `defaultFn`. If this exists it'll call it to get the value, otherwise it will use `default`. What do you think?