### PR TITLE
[hecs] Measure elapsed time (performance) of each system

### DIFF
--- a/packages/hecs/src/SystemManager.js
+++ b/packages/hecs/src/SystemManager.js
@@ -41,10 +41,14 @@ export class SystemManager {
   }
 
   update(delta) {
+    let timeBefore
+    const getTime = this.world.getTime
     for (let i = 0; i < this.systems.length; i++) {
       this.tick++
       const system = this.systems[i]
+      if (getTime) timeBefore = getTime()
       if (system.active) system.update(delta)
+      if (getTime) system.elapsedTime = getTime() - timeBefore
     }
   }
 

--- a/packages/hecs/src/World.js
+++ b/packages/hecs/src/World.js
@@ -18,6 +18,7 @@ export class World extends EventEmitter {
     this.archetypes = new ArchetypeManager(this)
     this.entities = new EntityManager(this)
     this.components = new ComponentManager(this)
+    this.getTime = options.getTime
     this.registerPlugin(
       createPlugin({
         name: 'root',

--- a/packages/hecs/tests/system-performance.test.js
+++ b/packages/hecs/tests/system-performance.test.js
@@ -1,0 +1,25 @@
+import { World, System } from '../src'
+import { performance } from 'perf_hooks'
+
+describe('system performance', () => {
+  test('measure system elapsed time', () => {
+    class SystemA extends System {}
+    class SystemB extends System {}
+    class SystemC extends System {}
+
+    const world = new World({
+      systems: [SystemA, SystemB, SystemC],
+      getTime: performance.now,
+    })
+
+    world.update(0)
+
+    const timeA = world.systems.get(SystemA).elapsedTime
+    const timeB = world.systems.get(SystemA).elapsedTime
+    const timeC = world.systems.get(SystemA).elapsedTime
+
+    expect(timeA).toBeGreaterThanOrEqual(0)
+    expect(timeB).toBeGreaterThanOrEqual(0)
+    expect(timeC).toBeGreaterThanOrEqual(0)
+  })
+})


### PR DESCRIPTION
Allows a `getTime` option to be passed in to World (i.e. `new World({ getTime: performance.now.bind(performance) })`) that can measure performance on the server or in the browser. Each system gets an `elapsedTime` result after each loop.

Fixes #33 