### PR TITLE
[hecs] Allow System and Component classes to specify className

### DIFF
--- a/packages/hecs/src/Component.js
+++ b/packages/hecs/src/Component.js
@@ -4,7 +4,7 @@ export class Component {
 
   constructor(world, values = {}) {
     this.world = world
-    this.name = this.constructor.name
+    this.name = this.constructor.className || this.constructor.name
     this.props = []
     this.modifiedUntilSystemTick = 0
 

--- a/packages/hecs/src/ComponentManager.js
+++ b/packages/hecs/src/ComponentManager.js
@@ -7,11 +7,12 @@ export class ComponentManager {
   }
 
   register(Component) {
-    if (this.componentsByName[Component.name]) {
-      throw new Error(`hecs: component already registered '${Component.name}'`)
+    const name = Component.className || Component.name
+    if (this.componentsByName[name]) {
+      throw new Error(`hecs: component already registered '${name}'`)
     }
     Component.id = this.lastComponentId++
-    this.componentsByName[Component.name] = Component
+    this.componentsByName[name] = Component
     this.count++
     return this
   }

--- a/packages/hecs/src/SystemManager.js
+++ b/packages/hecs/src/SystemManager.js
@@ -8,8 +8,9 @@ export class SystemManager {
   }
 
   register(System) {
+    const name = System.className || System.name
     if (this.Systems.has(System)) {
-      console.warn(`hecs: already registered system '${System.name}'`)
+      console.warn(`hecs: already registered system '${name}'`)
       return
     }
     const system = new System(this.world)
@@ -21,7 +22,7 @@ export class SystemManager {
       position = i + 1
     }
     this.systems.splice(position, 0, system)
-    this.systemsByName[System.name] = system
+    this.systemsByName[name] = system
     return this
   }
 

--- a/packages/hecs/tests/class-name.test.js
+++ b/packages/hecs/tests/class-name.test.js
@@ -1,0 +1,56 @@
+import { World, System, Component } from '../src'
+
+class Fallback extends Component {}
+
+class Model extends Component {
+  static className = 'AltModel'
+}
+
+class FallbackSystem extends System {}
+
+class ModelSystem extends System {
+  static className = 'AltModelSystem'
+}
+
+describe('className', () => {
+  const world = new World({
+    systems: [ModelSystem, FallbackSystem],
+    components: [Model, Fallback],
+  })
+
+  test('component uses name', () => {
+    const entity = world.entities.create('e1').add(Fallback)
+    const fallback = entity.get(Fallback)
+    expect(fallback.name).toEqual('Fallback')
+  })
+
+  test('component prefers className if provided', () => {
+    const entity = world.entities.create('e1').add(Model)
+    const model = entity.get(Model)
+    expect(model.name).toEqual('AltModel')
+  })
+
+  test('Component uses name', () => {
+    const fallbackComponent = world.components.componentsByName['Fallback']
+    expect(fallbackComponent).toEqual(Fallback)
+  })
+
+  test('Component prefers className if provided', () => {
+    expect(world.components.componentsByName['Model']).toBeUndefined()
+
+    const modelComponent = world.components.componentsByName['AltModel']
+    expect(modelComponent).toEqual(Model)
+  })
+
+  test('System uses name', () => {
+    const fallbackSystem = world.systems.getByName('FallbackSystem')
+    expect(fallbackSystem.constructor).toEqual(FallbackSystem)
+  })
+
+  test('System prefers className if provided', () => {
+    expect(world.systems.getByName('ModelSystem')).toBeUndefined()
+
+    const modelSystem = world.systems.getByName('AltModelSystem')
+    expect(modelSystem.constructor).toEqual(ModelSystem)
+  })
+})


### PR DESCRIPTION
With this change, a Component or System can reliably describe its own class name, regardless of down-line minification:

```js
class Model extends Component {
  static className = "Model"
  static props = {
  ...
  }
}
```

Since this decouples the class name from self-described `className`, this also provides a way to change class names / migrate code without affecting network or save game data.

Fixes #31 