### PR TITLE
[hecs] Add entity.getByName

### DIFF
--- a/packages/hecs/src/Entity.js
+++ b/packages/hecs/src/Entity.js
@@ -40,6 +40,11 @@ export class Entity {
     return this.components.get(Component)
   }
 
+  getByName(componentName) {
+    const Component = this.world.components.getByName(componentName)
+    return this.get(Component)
+  }
+
   has(Component) {
     return !!this.components.get(Component)
   }

--- a/packages/hecs/tests/components.test.js
+++ b/packages/hecs/tests/components.test.js
@@ -37,6 +37,12 @@ describe('components', () => {
     expect(system.counts.active).toBe(1)
   })
 
+  test('get component by name', () => {
+    block.add(Model)
+    const model = block.getByName('Model')
+    expect(model).toEqual(block.get(Model))
+  })
+
   test('deactivate entity', () => {
     /**
      * Because the entity has no StateComponents, the entity


### PR DESCRIPTION
Provides a way to get a component when only the name of the component is known.

Useful when synchronizing entities with incoming deltas, e.g. from the network.